### PR TITLE
Providing changes to align with open-drain character of the w1 bus

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -185,7 +185,7 @@ void OneWire::write_bit(uint8_t v)
 		DIRECT_WRITE_LOW(reg, mask);
 		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
 		delayMicroseconds(65);
-		DIRECT_MODE_INPUT(reg, mask);	// drive high on the pull-up
+		DIRECT_MODE_INPUT(reg, mask);	// drive high by the pull-up
 		interrupts();
 		delayMicroseconds(5);
 	}
@@ -205,7 +205,7 @@ uint8_t OneWire::read_bit(void)
 	DIRECT_WRITE_LOW(reg, mask);
 	DIRECT_MODE_OUTPUT(reg, mask);
 	delayMicroseconds(5);
-	DIRECT_MODE_INPUT(reg, mask);	// drive high on the pull-up
+	DIRECT_MODE_INPUT(reg, mask);	// drive high by the pull-up
 	delayMicroseconds(8);
 	r = DIRECT_READ(reg, mask);	// start sampling at 13us
 	interrupts();
@@ -271,15 +271,16 @@ uint8_t OneWire::touch(uint8_t v)
 	uint8_t r = 0;
 
 	for (bitMask = 0x01; bitMask; bitMask <<= 1) {
-		if (OneWire::touch_bit(v)) r |= bitMask;
+		if (OneWire::touch_bit((bitMask & v)?1:0)) r|=bitMask;
 	}
 	return r;
 }
 
 void OneWire::touch_bytes(uint8_t *buf, uint16_t count)
 {
-	for (uint16_t i = 0 ; i < count ; i++)
+	for (uint16_t i = 0 ; i < count ; i++) {
 		buf[i] = OneWire::touch(buf[i]);
+	}
 }
 
 //

--- a/OneWire.h
+++ b/OneWire.h
@@ -200,20 +200,20 @@ class OneWire
     // Read a bit.
     uint8_t read_bit(void);
 
-    // Touches a bit.
+    // Touch a bit.
     // 1-wire bus touching depends on a touched bit 'v' as follows:
     //  0: writes 0 on the bus, there is no bus sampling in this case
     //     (the function returns 0),
-    //  1: writes 1 on the bus and samples for response. The response is
-    //     returned by the function.
+    //  1: writes 1 on the bus and samples for response (this is equal to
+    //     reading a bit). The response is returned.
     uint8_t touch_bit(uint8_t v) {
         return ((v&1) ? read_bit() : (write_bit(0), 0));
     }
 
-    // Touches a byte and returns result.
+    // Touch a byte and return result.
     uint8_t touch(uint8_t v);
 
-    // Touches an array of bytes. Result is passed back in the same buffer.
+    // Touch an array of bytes. Result is passed back in the same buffer.
     void touch_bytes(uint8_t *buf, uint16_t count);
 
     // Stop forcing power onto the bus. You only need to do this if

--- a/OneWire.h
+++ b/OneWire.h
@@ -200,6 +200,22 @@ class OneWire
     // Read a bit.
     uint8_t read_bit(void);
 
+    // Touches a bit.
+    // 1-wire bus touching depends on a touched bit 'v' as follows:
+    //  0: writes 0 on the bus, there is no bus sampling in this case
+    //     (the function returns 0),
+    //  1: writes 1 on the bus and samples for response. The response is
+    //     returned by the function.
+    uint8_t touch_bit(uint8_t v) {
+        return ((v&1) ? read_bit() : (write_bit(0), 0));
+    }
+
+    // Touches a byte and returns result.
+    uint8_t touch(uint8_t v);
+
+    // Touches an array of bytes. Result is passed back in the same buffer.
+    void touch_bytes(uint8_t *buf, uint16_t count);
+
     // Stop forcing power onto the bus. You only need to do this if
     // you used the 'power' flag to write() or used a write_bit() call
     // and aren't about to do another read or write. You would rather

--- a/OneWire.h
+++ b/OneWire.h
@@ -56,7 +56,8 @@
 #define IO_REG_TYPE uint8_t
 #define IO_REG_ASM asm("r30")
 #define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
-#define DIRECT_MODE_INPUT(base, mask)   ((*((base)+1)) &= ~(mask))
+// input with no internal pull-up
+#define DIRECT_MODE_INPUT(base, mask)   (((*((base)+1)) &= ~(mask)), DIRECT_WRITE_LOW(base, mask))
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+1)) |= (mask))
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+2)) &= ~(mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+2)) |= (mask))

--- a/examples/DS18x20_Temp_Touch/DS18x20_Temp_Touch.pde
+++ b/examples/DS18x20_Temp_Touch/DS18x20_Temp_Touch.pde
@@ -1,0 +1,119 @@
+#include <OneWire.h>
+
+// OneWire DS18S20, DS18B20, DS1822 Temperature Example using w1 bus touch
+// approach
+//
+// http://www.pjrc.com/teensy/td_libs_OneWire.html
+//
+// The DallasTemperature library can do all this work for you!
+// http://milesburton.com/Dallas_Temperature_Control_Library
+
+OneWire  ds(10);  // on pin 10 (a 4.7K resistor is necessary)
+
+void setup(void) {
+  Serial.begin(9600);
+}
+
+void loop(void) {
+  byte i;
+  byte present = 0;
+  byte type_s;
+  byte addr[8];
+  float celsius, fahrenheit;
+
+  if ( !ds.search(addr)) {
+    Serial.println("No more addresses.");
+    Serial.println();
+    ds.reset_search();
+    delay(250);
+    return;
+  }
+
+  Serial.print("ROM =");
+  for( i = 0; i < 8; i++) {
+    Serial.write(' ');
+    Serial.print(addr[i], HEX);
+  }
+
+  if (OneWire::crc8(addr, 7) != addr[7]) {
+      Serial.println("CRC is not valid!");
+      return;
+  }
+  Serial.println();
+
+  // the first ROM byte indicates which chip
+  switch (addr[0]) {
+    case 0x10:
+      Serial.println("  Chip = DS18S20");  // or old DS1820
+      type_s = 1;
+      break;
+    case 0x28:
+      Serial.println("  Chip = DS18B20");
+      type_s = 0;
+      break;
+    case 0x22:
+      Serial.println("  Chip = DS1822");
+      type_s = 0;
+      break;
+    default:
+      Serial.println("Device is not a DS18x20 family device.");
+      return;
+  }
+
+  ds.reset();
+  ds.select(addr);
+  ds.write(0x44, 1);        // start conversion, with parasite power on at the end
+
+  delay(1000);     // maybe 750ms is enough, maybe not
+  // we might do a ds.depower() here, but the reset will take care of it.
+
+  uint8_t touch_scrpd[] = {
+      // Read Scratchpad
+      0xBE,
+      // the read scratchpad will be placed here (9 bytes)
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+  };
+
+  present = ds.reset();
+  ds.select(addr);
+  ds.touch_bytes(touch_scrpd, sizeof(touch_scrpd));
+  uint8_t *data = &touch_scrpd[1];  // scratchpad read
+
+  Serial.print("  Data = ");
+  Serial.print(present, HEX);
+  Serial.print(" ");
+  for ( i = 0; i < sizeof(touch_scrpd)-1; i++) {
+    Serial.print(data[i], HEX);
+    Serial.print(" ");
+  }
+  Serial.print(" CRC=");
+  Serial.print(OneWire::crc8(data, 8), HEX);
+  Serial.println();
+
+  // Convert the data to actual temperature
+  // because the result is a 16 bit signed integer, it should
+  // be stored to an "int16_t" type, which is always 16 bits
+  // even when compiled on a 32 bit processor.
+  int16_t raw = (data[1] << 8) | data[0];
+  if (type_s) {
+    raw = raw << 3; // 9 bit resolution default
+    if (data[7] == 0x10) {
+      // "count remain" gives full 12 bit resolution
+      raw = (raw & 0xFFF0) + 12 - data[6];
+    }
+  } else {
+    byte cfg = (data[4] & 0x60);
+    // at lower res, the low bits are undefined, so let's zero them
+    if (cfg == 0x00) raw = raw & ~7;  // 9 bit resolution, 93.75 ms
+    else if (cfg == 0x20) raw = raw & ~3; // 10 bit res, 187.5 ms
+    else if (cfg == 0x40) raw = raw & ~1; // 11 bit res, 375 ms
+    //// default is 12 bit resolution, 750 ms conversion time
+  }
+  celsius = (float)raw / 16.0;
+  fahrenheit = celsius * 1.8 + 32.0;
+  Serial.print("  Temperature = ");
+  Serial.print(celsius);
+  Serial.print(" Celsius, ");
+  Serial.print(fahrenheit);
+  Serial.println(" Fahrenheit");
+}


### PR DESCRIPTION
The changes are:
1. Modifications of low level w1 bus activites (read/write bit/byte/bytes) to align with open-drain character of the w1 bus. Providing direct voltage on the open-drain medium (as in the current version) is asking for troubles and may cause damage of some types of slaves. To mimic open-drain output all high GPIO outputs on the data wire are replaced by switching the data GPIO to the input mode and therefore setting the wire high by the pull-up resistor.
2. write() and write_bytes() handling of the power supply in the parasitic mode is changed accordingly. From now bus in the high state is always provided with the voltage by the pull-up resistor.
3. Added touch bus activities. If you need more info about this activity look at Maxim's iButton related spec:
http://pdfserv.maximintegrated.com/en/an/AN937.pdf
4. Provided example for DS temperature sensors using new touch functionality. I'm not sure it's really needed but added it to illustrate the new functionality.

NOTE: The changes were tested on the AVR platform (ATmega328) with DS temp. sensors with and w/o parasitic mode. I'd be grateful for more tests on other platforms and slaves.
