### PR TITLE
Added begin method

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -12,6 +12,9 @@ works on OneWire every 6 to 12 months.  Patches usually wait that
 long.  If anyone is interested in more actively maintaining OneWire,
 please contact Paul.
 
+Version 2.3-glmfork:
+  Added .begin() method
+
 Version 2.3:
   Unknonw chip fallback mode, Roger Clark
   Teensy-LC compatibility, Paul Stoffregen
@@ -121,18 +124,21 @@ sample code bearing this copyright.
 
 #include "OneWire.h"
 
-
-OneWire::OneWire(uint8_t pin)
+OneWire::OneWire() 
 {
-	pinMode(pin, INPUT);
-	bitmask = PIN_TO_BITMASK(pin);
-	baseReg = PIN_TO_BASEREG(pin);
-#if ONEWIRE_SEARCH
-	reset_search();
-#endif
+  // empty constructor
 }
 
+void OneWire::begin(uint8_t pin)
+{
+  pinMode(pin, INPUT);
+  bitmask = PIN_TO_BITMASK(pin);
+  baseReg = PIN_TO_BASEREG(pin);
+#if ONEWIRE_SEARCH
+  reset_search();
+#endif
 
+}
 // Perform the onewire reset function.  We will wait up to 250uS for
 // the bus to come high, if it doesn't then it is broken or shorted
 // and we return a 0;

--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -124,9 +124,10 @@ sample code bearing this copyright.
 
 #include "OneWire.h"
 
-OneWire::OneWire() 
-{
-  // empty constructor
+OneWire::OneWire() { } // empty constructor
+OneWire::OneWire(uint8_t pin) 
+{ // old style constructor, with onewire pin provided
+  begin(pin); // pass along pin to the new begin method
 }
 
 void OneWire::begin(uint8_t pin)

--- a/OneWire.h
+++ b/OneWire.h
@@ -267,6 +267,7 @@ class OneWire
 
   public:
     OneWire();
+    OneWire( uint8_t pin );
 
     // begin method allowing one wire pin to be set under Setup instead of in the constructor
     void begin( uint8_t pin );

--- a/OneWire.h
+++ b/OneWire.h
@@ -266,7 +266,10 @@ class OneWire
 #endif
 
   public:
-    OneWire( uint8_t pin);
+    OneWire();
+
+    // begin method allowing one wire pin to be set under Setup instead of in the constructor
+    void begin( uint8_t pin );
 
     // Perform a 1-Wire reset cycle. Returns 1 if a device responds
     // with a presence pulse.  Returns 0 if there is no device or the

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+#OneWire
+This is a fork of Paul Stoffregen's OneWire library. I made a simple change, adding a begin method, allowing you to dynamically assign a onewire bus pin.
+
+Usage:
+
+In your globals:
+
+OneWire oneWire;
+
+In Setup (or other applicable function)
+
+oneWire.begin(pin); // where pin is the gpio pin your onewire bus is connected to
+ 

--- a/library.json
+++ b/library.json
@@ -49,6 +49,10 @@
     {
         "name": "Scott Roberts"
     }
+    {
+        "name": "Gordon McLellan",
+        "email": "gordonthree@gmail.com"
+    }
 ],
 "repository":
 {

--- a/library.json
+++ b/library.json
@@ -57,6 +57,6 @@
 "repository":
 {
     "type": "git",
-    "url": "https://github.com/PaulStoffregen/OneWire"
+    "url": "https://github.com/gordonthree/OneWire"
 }
 }

--- a/library.json
+++ b/library.json
@@ -1,59 +1,7 @@
 {
 "name": "OneWire",
-"frameworks": "Arduino",
 "keywords": "onewire, 1-wire, bus, sensor, temperature, ibutton",
 "description": "Control 1-Wire protocol (DS18S20, DS18B20, DS2408 and etc)",
-"authors":
-[
-    {
-        "name": "Paul Stoffregen",
-        "email": "paul@pjrc.com",
-        "url": "http://www.pjrc.com",
-        "maintainer": true
-    },
-    {
-        "name": "Jim Studt"
-    },
-    {
-        "name": "Tom Pollard",
-        "email": "pollard@alum.mit.edu"
-    },
-    {
-        "name": "Derek Yerger"
-    },
-    {
-        "name": "Josh Larios"
-    },
-    {
-        "name": "Robin James"
-    },
-    {
-        "name": "Glenn Trewitt"
-    },
-    {
-        "name": "Jason Dangel",
-        "email": "dangel.jason AT gmail.com"
-    },
-    {
-        "name": "Guillermo Lovato"
-    },
-    {
-        "name": "Ken Butcher"
-    },
-    {
-        "name": "Mark Tillotson"
-    },
-    {
-        "name": "Bertrik Sikken"
-    },
-    {
-        "name": "Scott Roberts"
-    }
-    {
-        "name": "Gordon McLellan",
-        "email": "gordonthree@gmail.com"
-    }
-],
 "repository":
 {
     "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=OneWire
 version=2.3.2
-author=Jim Studt, Tom Pollard, Robin James, Glenn Trewitt, Jason Dangel, Guillermo Lovato, Paul Stoffregen, Scott Roberts, Bertrik Sikken, Mark Tillotson, Ken Butcher, Roger Clark, Love Nystrom
+author=Jim Studt, Tom Pollard, Robin James, Glenn Trewitt, Jason Dangel, Guillermo Lovato, Paul Stoffregen, Scott Roberts, Bertrik Sikken, Mark Tillotson, Ken Butcher, Roger Clark, Love Nystrom, Gordon McLEllan
 maintainer=Paul Stoffregen
 sentence=Access 1-wire temperature sensors, memory and other chips.
 paragraph=


### PR DESCRIPTION
Needing a way to change the onewire pin dynamically, based on configuration from an api server, I added a begin method to the OneWire class. The previous method of setting the pin in the constructor is preserved.

Looks like my editor messed up indentation for the changes, using space instead of tab, oops!
