### PR TITLE
Added compatbility for RedBearLab nRF51822 and BLENano

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -152,20 +152,20 @@ uint8_t OneWire::reset(void)
 	// wait until the wire is high... just in case
 	do {
 		if (--retries == 0) return 0;
-		delayMicroseconds(2);
+		DELAY_MICROSECONDS(2);
 	} while ( !DIRECT_READ(reg, mask));
 
 	noInterrupts();
 	DIRECT_WRITE_LOW(reg, mask);
 	DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
 	interrupts();
-	delayMicroseconds(480);
+	DELAY_MICROSECONDS(480);
 	noInterrupts();
 	DIRECT_MODE_INPUT(reg, mask);	// allow it to float
-	delayMicroseconds(70);
+	DELAY_MICROSECONDS(70);
 	r = !DIRECT_READ(reg, mask);
 	interrupts();
-	delayMicroseconds(410);
+	DELAY_MICROSECONDS(410);
 	return r;
 }
 
@@ -182,18 +182,18 @@ void OneWire::write_bit(uint8_t v)
 		noInterrupts();
 		DIRECT_WRITE_LOW(reg, mask);
 		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
-		delayMicroseconds(10);
+		DELAY_MICROSECONDS(10);
 		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
 		interrupts();
-		delayMicroseconds(55);
+		DELAY_MICROSECONDS(55);
 	} else {
 		noInterrupts();
 		DIRECT_WRITE_LOW(reg, mask);
 		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
-		delayMicroseconds(65);
+		DELAY_MICROSECONDS(65);
 		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
 		interrupts();
-		delayMicroseconds(5);
+		DELAY_MICROSECONDS(5);
 	}
 }
 
@@ -210,12 +210,12 @@ uint8_t OneWire::read_bit(void)
 	noInterrupts();
 	DIRECT_MODE_OUTPUT(reg, mask);
 	DIRECT_WRITE_LOW(reg, mask);
-	delayMicroseconds(3);
+	DELAY_MICROSECONDS(3);
 	DIRECT_MODE_INPUT(reg, mask);	// let pin float, pull up will raise
-	delayMicroseconds(10);
+	DELAY_MICROSECONDS(10);
 	r = DIRECT_READ(reg, mask);
 	interrupts();
-	delayMicroseconds(53);
+	DELAY_MICROSECONDS(53);
 	return r;
 }
 

--- a/OneWire.h
+++ b/OneWire.h
@@ -68,6 +68,7 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+1)) |= (mask))
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+2)) &= ~(mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+2)) |= (mask))
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK66FX1M0__) || defined(__MK64FX512__)
 #define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
@@ -79,6 +80,7 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  (*((base)+640) = 1)
 #define DIRECT_WRITE_LOW(base, mask)    (*((base)+256) = 1)
 #define DIRECT_WRITE_HIGH(base, mask)   (*((base)+128) = 1)
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(__MKL26Z64__)
 #define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
@@ -90,6 +92,7 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  (*((base)+20) |= (mask))
 #define DIRECT_WRITE_LOW(base, mask)    (*((base)+8) = (mask))
 #define DIRECT_WRITE_HIGH(base, mask)   (*((base)+4) = (mask))
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(__SAM3X8E__) || defined(__SAM3A8C__) || defined(__SAM3A4C__)
 // Arduino 1.5.1 may have a bug in delayMicroseconds() on Arduino Due.
@@ -105,6 +108,7 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+4)) = (mask))
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+13)) = (mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+12)) = (mask))
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 #ifndef PROGMEM
 #define PROGMEM
 #endif
@@ -122,6 +126,7 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*(base+1)) = (mask))            //TRISXCLR + 0x04
 #define DIRECT_WRITE_LOW(base, mask)    ((*(base+8+1)) = (mask))          //LATXCLR  + 0x24
 #define DIRECT_WRITE_HIGH(base, mask)   ((*(base+8+2)) = (mask))          //LATXSET + 0x28
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(ARDUINO_ARCH_ESP8266)
 #define PIN_TO_BASEREG(pin)             ((volatile uint32_t*) GPO)
@@ -133,6 +138,7 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  (GPE |= (mask))             //GPIO_ENABLE_W1TS_ADDRESS
 #define DIRECT_WRITE_LOW(base, mask)    (GPOC = (mask))             //GPIO_OUT_W1TC_ADDRESS
 #define DIRECT_WRITE_HIGH(base, mask)   (GPOS = (mask))             //GPIO_OUT_W1TS_ADDRESS
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(__SAMD21G18A__)
 #define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
@@ -144,8 +150,10 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+2)) = (mask))
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+5)) = (mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+6)) = (mask))
+#define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(RBL_NRF51822)
+#include <nRF51822.h>
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             (pin)
 #define IO_REG_TYPE uint32_t
@@ -155,6 +163,20 @@
 #define DIRECT_WRITE_HIGH(base, pin)    nrf_gpio_pin_set(pin)
 #define DIRECT_MODE_INPUT(base, pin)    nrf_gpio_cfg_input(pin, NRF_GPIO_PIN_NOPULL)
 #define DIRECT_MODE_OUTPUT(base, pin)   nrf_gpio_cfg_output(pin)
+#define DELAY_MICROSECONDS(us)		nrf_delay_us(us)
+
+#elif defined(BLE_NANO)
+#include <nRF51822.h>
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_ASM
+#define DIRECT_READ(base, pin)          nrf_gpio_pin_read(pin)
+#define DIRECT_WRITE_LOW(base, pin)     nrf_gpio_pin_clear(pin)
+#define DIRECT_WRITE_HIGH(base, pin)    nrf_gpio_pin_set(pin)
+#define DIRECT_MODE_INPUT(base, pin)    nrf_gpio_cfg_input(pin, NRF_GPIO_PIN_NOPULL)
+#define DIRECT_MODE_OUTPUT(base, pin)   nrf_gpio_cfg_output(pin)
+#define DELAY_MICROSECONDS(us)		nrf_delay_us(us)
 
 #elif defined(__arc__) /* Arduino101/Genuino101 specifics */
 

--- a/OneWire.h
+++ b/OneWire.h
@@ -153,7 +153,7 @@
 #define DELAY_MICROSECONDS(us)		delayMicroseconds(us)
 
 #elif defined(RBL_NRF51822)
-#include <nRF51822.h>
+#include <nRF51822_API.h>
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             (pin)
 #define IO_REG_TYPE uint32_t
@@ -166,7 +166,7 @@
 #define DELAY_MICROSECONDS(us)		nrf_delay_us(us)
 
 #elif defined(BLE_NANO)
-#include <nRF51822.h>
+#include <nRF51822_API.h>
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             (pin)
 #define IO_REG_TYPE uint32_t


### PR DESCRIPTION
As by "mrvanes" mentioned in this issue (https://github.com/PaulStoffregen/OneWire/issues/3) there were timing issues for using the OneWire library with RedBearLab's nRF51822 products. He mentioned a simple solution by adding another high level wrapper for DELAY_MICROSECONDS(...) in conclusion with including the <nRF51822_API.h> header for using all the necessary nRF specific functions. By including the nRF SDK to your compiler include paths the library was tested with my nRF51822 (v1.0/v1.5) and BLENano (v1.0/v1.5) by reading the sensor data from various DS18B20 sensors.