### PR TITLE
ESP32 fixes

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -64,9 +64,9 @@ http://www.pjrc.com/teensy/td_libs_OneWire.html
   Search fix from Robin James
     http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295/27#27
   Use direct optimized I/O in all cases
-  Disable CS_END during timing critical sections
+  Disable interrupts during timing critical sections
     (this solves many random communication errors)
-  Disable CS_END during read-modify-write I/O
+  Disable interrupts during read-modify-write I/O
   Reduce RAM consumption by eliminating unnecessary
     variables and trimming many to 8 bits
   Optimize both crc8 - table version moved to flash

--- a/OneWire.h
+++ b/OneWire.h
@@ -178,6 +178,7 @@ class OneWire
 
 // Undefine macros from OneWire_direct_gpio.h
 // Do not allow these to "leak" into Arduino sketches and other libraries
+/*
 #undef OneWire_Direct_GPIO_h
 #undef PIN_TO_BASEREG
 #undef PIN_TO_BITMASK
@@ -193,5 +194,5 @@ class OneWire
   #undef noInterrupts()
   #undef interrupts()
 #endif
-
+*/
 #endif

--- a/OneWire.h
+++ b/OneWire.h
@@ -178,7 +178,6 @@ class OneWire
 
 // Undefine macros from OneWire_direct_gpio.h
 // Do not allow these to "leak" into Arduino sketches and other libraries
-/*
 #undef OneWire_Direct_GPIO_h
 #undef PIN_TO_BASEREG
 #undef PIN_TO_BITMASK
@@ -190,9 +189,6 @@ class OneWire
 #undef DIRECT_MODE_OUTPUT
 #undef DIRECT_WRITE_LOW
 #undef DIRECT_WRITE_HIGH
-#ifdef ARDUINO_ARCH_ESP32
-  #undef noInterrupts()
-  #undef interrupts()
-#endif
-*/
+#undef CS_START
+#undef CS_END
 #endif

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -100,105 +100,21 @@
 #define DIRECT_WRITE_HIGH(base, mask)   (GPOS = (mask))             //GPIO_OUT_W1TS_ADDRESS
 
 #elif defined(ARDUINO_ARCH_ESP32)
-#include <driver/rtc_io.h>
-#define PIN_TO_BASEREG(pin)             (0)
-#define PIN_TO_BITMASK(pin)             (pin)
+#include <soc/gpio_reg.h>
+#define PIN_TO_BASEREG(pin)             ((volatile uint32_t*)((pin < 32) ? 1 : 0))
+#define PIN_TO_BITMASK(pin)             ((pin < 32) ? (1 << pin) : (1 << (pin - 32)))
 #define IO_REG_TYPE uint32_t
 #define IO_REG_BASE_ATTR
 #define IO_REG_MASK_ATTR
-
-static inline __attribute__((always_inline))
-IO_REG_TYPE directRead(IO_REG_TYPE pin)
-{
-    if ( pin < 32 )
-        return (GPIO.in >> pin) & 0x1;
-    else if ( pin < 40 )
-        return (GPIO.in1.val >> (pin - 32)) & 0x1;
-
-    return 0;
-}
-
-static inline __attribute__((always_inline))
-void directWriteLow(IO_REG_TYPE pin)
-{
-    if ( pin < 32 )
-        GPIO.out_w1tc = ((uint32_t)1 << pin);
-    else if ( pin < 34 )
-        GPIO.out1_w1tc.val = ((uint32_t)1 << (pin - 32));
-}
-
-static inline __attribute__((always_inline))
-void directWriteHigh(IO_REG_TYPE pin)
-{
-    if ( pin < 32 )
-        GPIO.out_w1ts = ((uint32_t)1 << pin);
-    else if ( pin < 34 )
-        GPIO.out1_w1ts.val = ((uint32_t)1 << (pin - 32));
-}
-
-static inline __attribute__((always_inline))
-void directModeInput(IO_REG_TYPE pin)
-{
-    if ( digitalPinIsValid(pin) )
-    {
-        uint32_t rtc_reg(rtc_gpio_desc[pin].reg);
-
-        if ( rtc_reg ) // RTC pins PULL settings
-        {
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].mux);
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
-        }
-
-        if ( pin < 32 )
-            GPIO.enable_w1tc = ((uint32_t)1 << pin);
-        else
-            GPIO.enable1_w1tc.val = ((uint32_t)1 << (pin - 32));
-
-        uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
-        pinFunction |= FUN_IE; // input enable but required for output as well?
-        pinFunction |= ((uint32_t)2 << MCU_SEL_S);
-
-        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
-
-        GPIO.pin[pin].val = 0;
-    }
-}
-
-static inline __attribute__((always_inline))
-void directModeOutput(IO_REG_TYPE pin)
-{
-    if ( digitalPinIsValid(pin) && pin <= 33 ) // pins above 33 can be only inputs
-    {
-        uint32_t rtc_reg(rtc_gpio_desc[pin].reg);
-
-        if ( rtc_reg ) // RTC pins PULL settings
-        {
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].mux);
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
-        }
-
-        if ( pin < 32 )
-            GPIO.enable_w1ts = ((uint32_t)1 << pin);
-        else // already validated to pins <= 33
-            GPIO.enable1_w1ts.val = ((uint32_t)1 << (pin - 32));
-
-        uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
-        pinFunction |= FUN_IE; // input enable but required for output as well?
-        pinFunction |= ((uint32_t)2 << MCU_SEL_S);
-
-        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
-
-        GPIO.pin[pin].val = 0;
-    }
-}
-
-#define DIRECT_READ(base, pin)          directRead(pin)
-#define DIRECT_WRITE_LOW(base, pin)     directWriteLow(pin)
-#define DIRECT_WRITE_HIGH(base, pin)    directWriteHigh(pin)
-#define DIRECT_MODE_INPUT(base, pin)    directModeInput(pin)
-#define DIRECT_MODE_OUTPUT(base, pin)   directModeOutput(pin)
+#define DIRECT_READ(base, mask)          (base ? ((GPIO.in & mask) ? 1 : 0) : ((GPIO.in1.val & mask) ? 1 : 0))
+#define DIRECT_MODE_INPUT(base, mask)    (base ? (GPIO.enable_w1tc = (mask)) : (GPIO.enable1_w1tc.val = (mask)))
+#define DIRECT_MODE_OUTPUT(base, mask)   (base ? (GPIO.enable_w1ts = (mask)) : (GPIO.enable1_w1ts.val = (mask)))
+#define DIRECT_WRITE_LOW(base, mask)     (base ? (GPIO.out_w1tc = (mask)) : (GPIO.out1_w1tc.val = (mask)))
+#define DIRECT_WRITE_HIGH(base, mask)    (base ? (GPIO.out_w1ts = (mask)) : (GPIO.out1_w1ts.val = (mask)))
 // https://github.com/PaulStoffregen/OneWire/pull/47
 // https://github.com/stickbreaker/OneWire/commit/6eb7fc1c11a15b6ac8c60e5671cf36eb6829f82c
+#undef noInterrupts
+#undef interrupts
 #define noInterrupts() {portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;portENTER_CRITICAL(&mux)
 #define interrupts() portEXIT_CRITICAL(&mux);}
 #warning "ESP32 OneWire testing"

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -10,6 +10,10 @@
 #include "pins_arduino.h"  // for digitalPinToBitMask, etc
 #endif
 
+// Generic defaults
+#define CS_START()                      noInterrupts();
+#define CS_END()                        interrupts();
+
 // Platform specific I/O definitions
 
 #if defined(__AVR__)
@@ -113,10 +117,10 @@
 #define DIRECT_WRITE_HIGH(base, mask)    (base ? (GPIO.out_w1ts = (mask)) : (GPIO.out1_w1ts.val = (mask)))
 // https://github.com/PaulStoffregen/OneWire/pull/47
 // https://github.com/stickbreaker/OneWire/commit/6eb7fc1c11a15b6ac8c60e5671cf36eb6829f82c
-#undef noInterrupts
-#undef interrupts
-#define noInterrupts() {portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;portENTER_CRITICAL(&mux)
-#define interrupts() portEXIT_CRITICAL(&mux);}
+#undef CS_START
+#undef CS_END
+#define CS_START()                       {portMUX_TYPE mux = portMUX_INITIALIZER_UNLOCKED;portENTER_CRITICAL(&mux)
+#define CS_END()                         portEXIT_CRITICAL(&mux);}
 #warning "ESP32 OneWire testing"
 
 #elif defined(__SAMD21G18A__)


### PR DESCRIPTION
Compilation errors (#undef's in OneWire.h) and warnigs (added #undefs in
OneWire_direct.h)
Functionality (didn't work at all, was something in input/output modes)
Simplified to oneliners.