### PR TITLE
adding option to set pin later

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -142,6 +142,7 @@ sample code bearing this copyright.
 #include "OneWire.h"
 #include "util/OneWire_direct_gpio.h"
 
+OneWire::OneWire() {}
 
 OneWire::OneWire(uint8_t pin)
 {
@@ -150,6 +151,17 @@ OneWire::OneWire(uint8_t pin)
 	baseReg = PIN_TO_BASEREG(pin);
 #if ONEWIRE_SEARCH
 	reset_search();
+#endif
+}
+
+// Add regular function to change pin
+void OneWire::apin(uint8_t pin)
+{
+  pinMode(pin, INPUT);
+  bitmask = PIN_TO_BITMASK(5);
+  baseReg = PIN_TO_BASEREG(5);
+#if ONEWIRE_SEARCH
+ reset_search();
 #endif
 }
 

--- a/OneWire.h
+++ b/OneWire.h
@@ -74,7 +74,11 @@ class OneWire
 #endif
 
   public:
+    OneWire();
     OneWire( uint8_t pin);
+
+    // Function to change pin assignment
+    void apin( uint8_t pin);
 
     // Perform a 1-Wire reset cycle. Returns 1 if a device responds
     // with a presence pulse.  Returns 0 if there is no device or the


### PR DESCRIPTION
This help to define OW without pin (initially in global scope) and define it later in setup() / loop().

This allows storing of configuration of OW PINs e.g. on SPIFFS, so setup() can first read them and properly configure PINs.

E.g.:
```
OneWire oneWire_1, oneWire_2;

void setup() {
    // read PIN e.g. from SPIFFS

    Serial.println("Setup 1W T1");
    oneWire_1.apin(pin.toInt());  // Set the pin

    // then use normally
}
```