### PR TITLE
Replaced 256 entry CRC8 table with tiny 2x16 entry table

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -496,46 +496,34 @@ uint8_t OneWire::search(uint8_t *newAddr, bool search_mode /* = true */)
 //
 
 #if ONEWIRE_CRC8_TABLE
-// This table comes from Dallas sample code where it is freely reusable,
-// though Copyright (C) 2000 Dallas Semiconductor Corporation
-static const uint8_t PROGMEM dscrc_table[] = {
-      0, 94,188,226, 97, 63,221,131,194,156,126, 32,163,253, 31, 65,
-    157,195, 33,127,252,162, 64, 30, 95,  1,227,189, 62, 96,130,220,
-     35,125,159,193, 66, 28,254,160,225,191, 93,  3,128,222, 60, 98,
-    190,224,  2, 92,223,129, 99, 61,124, 34,192,158, 29, 67,161,255,
-     70, 24,250,164, 39,121,155,197,132,218, 56,102,229,187, 89,  7,
-    219,133,103, 57,186,228,  6, 88, 25, 71,165,251,120, 38,196,154,
-    101, 59,217,135,  4, 90,184,230,167,249, 27, 69,198,152,122, 36,
-    248,166, 68, 26,153,199, 37,123, 58,100,134,216, 91,  5,231,185,
-    140,210, 48,110,237,179, 81, 15, 78, 16,242,172, 47,113,147,205,
-     17, 79,173,243,112, 46,204,146,211,141,111, 49,178,236, 14, 80,
-    175,241, 19, 77,206,144,114, 44,109, 51,209,143, 12, 82,176,238,
-     50,108,142,208, 83, 13,239,177,240,174, 76, 18,145,207, 45,115,
-    202,148,118, 40,171,245, 23, 73,  8, 86,180,234,105, 55,213,139,
-     87,  9,235,181, 54,104,138,212,149,203, 41,119,244,170, 72, 22,
-    233,183, 85, 11,136,214, 52,106, 43,117,151,201, 74, 20,246,168,
-    116, 42,200,150, 21, 75,169,247,182,232, 10, 84,215,137,107, 53};
+// Dow-CRC using polynomial X^8 + X^5 + X^4 + X^0
+// Tiny 2x16 entry CRC table created by Arjen Lentz
+// See http://lentz.com.au/blog/calculating-crc-with-a-tiny-32-entry-lookup-table
+static const uint8_t PROGMEM dscrc2x16_table[] = {
+	0x00, 0x5E, 0xBC, 0xE2, 0x61, 0x3F, 0xDD, 0x83,
+	0xC2, 0x9C, 0x7E, 0x20, 0xA3, 0xFD, 0x1F, 0x41,
+	0x00, 0x9D, 0x23, 0xBE, 0x46, 0xDB, 0x65, 0xF8,
+	0x8C, 0x11, 0xAF, 0x32, 0xCA, 0x57, 0xE9, 0x74
+};
 
-//
 // Compute a Dallas Semiconductor 8 bit CRC. These show up in the ROM
-// and the registers.  (note: this might better be done without to
-// table, it would probably be smaller and certainly fast enough
-// compared to all those delayMicrosecond() calls.  But I got
-// confused, so I use this table from the examples.)
-//
+// and the registers.  (Use tiny 2x16 entry CRC table)
 uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 {
 	uint8_t crc = 0;
 
 	while (len--) {
-		crc = pgm_read_byte(dscrc_table + (crc ^ *addr++));
+		crc = *addr++ ^ crc;  // just re-using crc as intermediate
+		crc = pgm_read_byte(dscrc2x16_table + (crc & 0x0f)) ^
+		pgm_read_byte(dscrc2x16_table + 16 + ((crc >> 4) & 0x0f));
 	}
+
 	return crc;
 }
 #else
 //
 // Compute a Dallas Semiconductor 8 bit CRC directly.
-// this is much slower, but much smaller, than the lookup table.
+// this is much slower, but a little smaller, than the lookup table.
 //
 uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 {


### PR DESCRIPTION
Hi Paul - here's a little contribution, replacing the 256 byte CRC8 lookup table with a 2x16 byte one, thus saving 224 bytes.
See http://lentz.com.au/blog/calculating-crc-with-a-tiny-32-entry-lookup-table for details on how it works.