### PR TITLE
Add support for STM32 MCU based boards

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -226,6 +226,18 @@ void directModeOutput(IO_REG_TYPE pin)
 #define interrupts() portEXIT_CRITICAL(&mux);}
 //#warning "ESP32 OneWire testing"
 
+#elif defined(ARDUINO_ARCH_STM32)
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             ((uint32_t)digitalPinToPinName(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          digitalReadFast((PinName)pin)
+#define DIRECT_WRITE_LOW(base, pin)     digitalWriteFast((PinName)pin, LOW)
+#define DIRECT_WRITE_HIGH(base, pin)    digitalWriteFast((PinName)pin, HIGH)
+#define DIRECT_MODE_INPUT(base, pin)    pin_function((PinName)pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0))
+#define DIRECT_MODE_OUTPUT(base, pin)   pin_function((PinName)pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0))
+
 #elif defined(__SAMD21G18A__)
 #define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))

--- a/util/OneWire_direct_regtype.h
+++ b/util/OneWire_direct_regtype.h
@@ -30,6 +30,9 @@
 #define IO_REG_TYPE uint32_t
 #define IO_REG_MASK_ATTR
 
+#elif defined(ARDUINO_ARCH_STM32)
+#define IO_REG_TYPE uint32_t
+
 #elif defined(__SAMD21G18A__)
 #define IO_REG_TYPE uint32_t
 


### PR DESCRIPTION
Hi @PaulStoffregen 

This PR provide support of the  https://github.com/stm32duino/Arduino_Core_STM32
It will required version higher than 1.5.0, this will be the 1.6.0 which will be available in April.

Define used: `ARDUINO_ARCH_STM32`

Thanks in advance