### PR TITLE
Provide for extension of recovery time trec.

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -144,11 +144,12 @@ sample code bearing this copyright.
 #include "util/OneWire_direct_gpio.h"
 
 
-void OneWire::begin(uint8_t pin)
+void OneWire::begin(uint8_t pin,uint8_t trec /*=5*/)
 {
 	pinMode(pin, INPUT);
 	bitmask = PIN_TO_BITMASK(pin);
 	baseReg = PIN_TO_BASEREG(pin);
+  this->trec=trec;
 #if ONEWIRE_SEARCH
 	reset_search();
 #endif
@@ -215,7 +216,7 @@ void OneWire::write_bit(uint8_t v)
 		delayMicroseconds(65);
 		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
 		interrupts();
-		delayMicroseconds(5);
+		delayMicroseconds(trec); //configurable recovery time for longer networks
 	}
 }
 
@@ -237,7 +238,8 @@ uint8_t OneWire::read_bit(void)
 	delayMicroseconds(10);
 	r = DIRECT_READ(reg, mask);
 	interrupts();
-	delayMicroseconds(53);
+	delayMicroseconds(48);
+	delayMicroseconds(trec);
 	return r;
 }
 

--- a/OneWire.h
+++ b/OneWire.h
@@ -56,9 +56,10 @@
 
 class OneWire
 {
-  private:
+  protected:
     IO_REG_TYPE bitmask;
     volatile IO_REG_TYPE *baseReg;
+    uint8_t trec;
 
 #if ONEWIRE_SEARCH
     // global search state
@@ -70,8 +71,8 @@ class OneWire
 
   public:
     OneWire() { }
-    OneWire(uint8_t pin) { begin(pin); }
-    void begin(uint8_t pin);
+    OneWire(uint8_t pin,uint8_t trec=5) { begin(pin,trec); }
+    void begin(uint8_t pin,uint8_t trec);
 
     // Perform a 1-Wire reset cycle. Returns 1 if a device responds
     // with a presence pulse.  Returns 0 if there is no device or the


### PR DESCRIPTION
Longer recovery time is needed in some scenarios (as discussed by Dallas in their docs).
This change provides for that as an optional parameter to initialising a class instance. The default value (trec=5) makes no change to existent timing.

Tested observing the timing with a scope.