### PR TITLE
Mark IO_REG_BASE variables as unused on the ESP8266

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -108,7 +108,7 @@
 #define PIN_TO_BASEREG(pin)             ((volatile uint32_t*) GPO)
 #define PIN_TO_BITMASK(pin)             (1 << pin)
 #define IO_REG_TYPE uint32_t
-#define IO_REG_BASE_ATTR
+#define IO_REG_BASE_ATTR __attribute__((unused))
 #define IO_REG_MASK_ATTR
 #define DIRECT_READ(base, mask)         ((GPI & (mask)) ? 1 : 0)    //GPIO_IN_ADDRESS
 #define DIRECT_MODE_INPUT(base, mask)   (GPE &= ~(mask))            //GPIO_ENABLE_W1TC_ADDRESS


### PR DESCRIPTION
Fixes #74.