### PR TITLE
Turn power off after every search result

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -479,8 +479,9 @@ bool OneWire::search(uint8_t *newAddr, bool search_mode /* = true */)
    } else {
       for (int i = 0; i < 8; i++) newAddr[i] = ROM_NO[i];
    }
+   depower();
    return search_result;
-  }
+}
 
 #endif
 


### PR DESCRIPTION
The search process calls write_bit() so power is always left on.