### PR TITLE
Update OneWire_direct_gpio.h

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -108,7 +108,7 @@
 #define PIN_TO_BASEREG(pin)             ((volatile uint32_t*) GPO)
 #define PIN_TO_BITMASK(pin)             (1 << pin)
 #define IO_REG_TYPE uint32_t
-#define IO_REG_BASE_ATTR
+#define IO_REG_BASE_ATTR		__attribute__((unused))
 #define IO_REG_MASK_ATTR
 #define DIRECT_READ(base, mask)         ((GPI & (mask)) ? 1 : 0)    //GPIO_IN_ADDRESS
 #define DIRECT_MODE_INPUT(base, mask)   (GPE &= ~(mask))            //GPIO_ENABLE_W1TC_ADDRESS


### PR DESCRIPTION
This is to fix -Wunused-variable warning that comes up when using the OneWire library with the ESP8266

```
/home/rharrison/Arduino/libraries/OneWire/OneWire.cpp:167:24: warning: unused variable 'reg' [-Wunused-variable]
  volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
                        ^
/home/rharrison/Arduino/libraries/OneWire/OneWire.cpp: In member function 'void OneWire::write_bit(uint8_t)':
/home/rharrison/Arduino/libraries/OneWire/OneWire.cpp:201:24: warning: unused variable 'reg' [-Wunused-variable]
  volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
                        ^
/home/rharrison/Arduino/libraries/OneWire/OneWire.cpp: In member function 'uint8_t OneWire::read_bit()':
/home/rharrison/Arduino/libraries/OneWire/OneWire.cpp:229:24: warning: unused variable 'reg' [-Wunused-variable]
  volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
```