### PR TITLE
Add support for Heltec CubeCell/ASR6501/PSoC4

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -250,6 +250,23 @@ void directModeOutput(IO_REG_TYPE pin)
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+5)) = (mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+6)) = (mask))
 
+#elif defined(__ASR6501__)
+#define PIN_IN_PORT(pin)    (pin % PIN_NUMBER_IN_PORT)
+#define PORT_FROM_PIN(pin)  (pin / PIN_NUMBER_IN_PORT)
+#define PORT_OFFSET(port)   (PORT_REG_SHFIT * port)
+#define PORT_ADDRESS(pin)   (CYDEV_GPIO_BASE + PORT_OFFSET(PORT_FROM_PIN(pin)))
+
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+#define DIRECT_READ(base, pin)          CY_SYS_PINS_READ_PIN(PORT_ADDRESS(pin)+4, PIN_IN_PORT(pin))
+#define DIRECT_WRITE_LOW(base, pin)     CY_SYS_PINS_CLEAR_PIN(PORT_ADDRESS(pin), PIN_IN_PORT(pin))
+#define DIRECT_WRITE_HIGH(base, pin)    CY_SYS_PINS_SET_PIN(PORT_ADDRESS(pin), PIN_IN_PORT(pin))
+#define DIRECT_MODE_INPUT(base, pin)    CY_SYS_PINS_SET_DRIVE_MODE(PORT_ADDRESS(pin)+8, PIN_IN_PORT(pin), CY_SYS_PINS_DM_DIG_HIZ)
+#define DIRECT_MODE_OUTPUT(base, pin)   CY_SYS_PINS_SET_DRIVE_MODE(PORT_ADDRESS(pin)+8, PIN_IN_PORT(pin), CY_SYS_PINS_DM_STRONG)
+
 #elif defined(RBL_NRF51822)
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             (pin)

--- a/util/OneWire_direct_regtype.h
+++ b/util/OneWire_direct_regtype.h
@@ -36,6 +36,9 @@
 #elif defined(__SAMD21G18A__)
 #define IO_REG_TYPE uint32_t
 
+#elif defined(__ASR6501__)
+#define IO_REG_TYPE uint32_t
+
 #elif defined(RBL_NRF51822)
 #define IO_REG_TYPE uint32_t
 


### PR DESCRIPTION
Needs defined \_\_ASR6501__

Required for and tested with the [Heltec CubeCell dev](https://heltec.org/project/htcc-ab01/) board.
See also https://github.com/HelTecAutomation/ASR650x-Arduino.