### PR TITLE
Add support for the rest of the megaAVR 0-series, the tinyAVR 0/1-series, and the new AVR Dx-series, make interrupt safe.

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -16,7 +16,7 @@
 #define IO_REG_MASK_ATTR
 #if (__AVR_ARCH__ == 103) || (__AVR_ARCH__ == 104)
 #define PIN_TO_BASEREG(pin)             (((digitalPinToPort(pin))<<2))
-#define DIRECT_READ(base, mask)         (((*((base+2)) & (mask)) ? 1 : 0)
+#define DIRECT_READ(base, mask)         ((*((base+2)) & (mask)) ? 1 : 0)
 #define DIRECT_MODE_INPUT(base, mask)   ((*(base)) &= ~(mask))
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*(base)) |= (mask))
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+1)) &= ~(mask))

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -15,8 +15,8 @@
 #define IO_REG_BASE_ATTR asm("r30")
 #define IO_REG_MASK_ATTR
 #if (__AVR_ARCH__ == 103) || (__AVR_ARCH__ == 104)
-#define PIN_TO_BASEREG(pin)             (((digitalPinToPort(pin))<<2))
-#define DIRECT_READ(base, mask)         ((*((base+2)) & (mask)) ? 1 : 0)
+#define PIN_TO_BASEREG(pin)             ((volatile uint8_t*)((digitalPinToPort(pin))<<2))
+#define DIRECT_READ(base, mask)         ((*((base)+2) & (mask)) ? 1 : 0)
 #define DIRECT_MODE_INPUT(base, mask)   ((*(base)) &= ~(mask))
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*(base)) |= (mask))
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+1)) &= ~(mask))

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -15,7 +15,7 @@
 #define IO_REG_TYPE uint8_t
 #define IO_REG_BASE_ATTR asm("r30")
 #define IO_REG_MASK_ATTR
-#if defined(__AVR_ATmega4809__)
+#if (__AVR_ARCH__ == 103) || (__AVR_ARCH__ == 104)
 #define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
 #define DIRECT_MODE_INPUT(base, mask)   ((*((base)-8)) &= ~(mask))
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)-8)) |= (mask))

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -19,7 +19,7 @@
 #define DIRECT_READ(base, mask)         (((*((base+2)) & (mask)) ? 1 : 0)
 #define DIRECT_MODE_INPUT(base, mask)   ((*(base)) &= ~(mask))
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*(base)) |= (mask))
-#define DIRECT_WRITE_LOW(base, mask)    ((*(base)+1)) &= ~(mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+1)) &= ~(mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+1)) |= (mask))
 #else
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -10,18 +10,19 @@
 // Platform specific I/O definitions
 
 #if defined(__AVR__)
-#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define IO_REG_TYPE uint8_t
 #define IO_REG_BASE_ATTR asm("r30")
 #define IO_REG_MASK_ATTR
 #if (__AVR_ARCH__ == 103) || (__AVR_ARCH__ == 104)
-#define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
-#define DIRECT_MODE_INPUT(base, mask)   ((*((base)-8)) &= ~(mask))
-#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)-8)) |= (mask))
-#define DIRECT_WRITE_LOW(base, mask)    ((*((base)-4)) &= ~(mask))
-#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)-4)) |= (mask))
+#define PIN_TO_BASEREG(pin)             (((digitalPinToPort(pin))<<2))
+#define DIRECT_READ(base, mask)         (((*((base+2)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*(base)) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*(base)) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*(base)+1)) &= ~(mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+1)) |= (mask))
 #else
+#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
 #define DIRECT_MODE_INPUT(base, mask)   ((*((base)+1)) &= ~(mask))
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+1)) |= (mask))


### PR DESCRIPTION
These all have the same patterns in register locations, so can use the same formulae for them.

This also switches to using the VPORT registers instead of the PORT registers, which makes setting or clearing a single bit into an atomic, single word, single cycle operation (SBI/CBI), as opposed to requiring a read-modify-write cycle like the PORT.OUT and PORT.DIR registers do, making those operations interrupt safe like they were on classic AVRs, as well as reducing sketch size and executing faster. Taking advantage of the consistent numbering of ports returned by digitalPinToPort() among the cores supporting these parts to get the base register address shrinks the compiled sketch size a touch too. 

Non-pins passed to digitalPinToPort() will get back NOT_A_PORT, which is defined as 255, would give base reg of 0x03FC, which falls into one of the many gaps in the register space on these parts as well - so it won't fiddle with some random other peripheral somewhere (as it happens, it's right before where the PORT registers start at 0x0400, which seems fitting for "port -1")