### PR TITLE
Usage of "bool" in portable code

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -262,7 +262,7 @@ void OneWire::write(uint8_t v, uint8_t power /* = 0 */) {
     }
 }
 
-void OneWire::write_bytes(const uint8_t *buf, uint16_t count, bool power /* = 0 */) {
+void OneWire::write_bytes(const uint8_t *buf, uint16_t count, uint8_t power /* = 0 */) {
   for (uint16_t i = 0 ; i < count ; i++)
     write(buf[i]);
   if (!power) {

--- a/OneWire.h
+++ b/OneWire.h
@@ -90,7 +90,7 @@ class OneWire
     // another read or write.
     void write(uint8_t v, uint8_t power = 0);
 
-    void write_bytes(const uint8_t *buf, uint16_t count, bool power = 0);
+    void write_bytes(const uint8_t *buf, uint16_t count, uint8_t power = 0);
 
     // Read a byte.
     uint8_t read(void);


### PR DESCRIPTION
Changed OneWire::write_bytes power from "bool" to "uint8_t" for better portability

