### PR TITLE
Add support for new ATTiny MCUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -163,7 +163,7 @@ void OneWire::begin(uint8_t pin)
 //
 uint8_t OneWire::reset(void)
 {
-	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
+	IO_BITMASK_TYPE mask IO_REG_MASK_ATTR = bitmask;
 	volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
 	uint8_t r;
 	uint8_t retries = 125;
@@ -197,7 +197,7 @@ uint8_t OneWire::reset(void)
 //
 void OneWire::write_bit(uint8_t v)
 {
-	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
+	IO_BITMASK_TYPE mask IO_REG_MASK_ATTR = bitmask;
 	volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
 
 	if (v & 1) {
@@ -225,7 +225,7 @@ void OneWire::write_bit(uint8_t v)
 //
 uint8_t OneWire::read_bit(void)
 {
-	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
+	IO_BITMASK_TYPE mask IO_REG_MASK_ATTR = bitmask;
 	volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
 	uint8_t r;
 

--- a/OneWire.h
+++ b/OneWire.h
@@ -57,8 +57,8 @@
 class OneWire
 {
   private:
-    IO_REG_TYPE bitmask;
-    volatile IO_REG_TYPE *baseReg;
+	IO_BITMASK_TYPE bitmask;
+	volatile IO_REG_TYPE *baseReg;
 
 #if ONEWIRE_SEARCH
     // global search state

--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -9,7 +9,24 @@
 
 // Platform specific I/O definitions
 
-#if defined(__AVR__)
+#if (defined(__AVR_ATtiny804__) || defined(__AVR_ATtiny806__) || defined(__AVR_ATtiny807__) || defined(__AVR_ATtiny1604__) \
+  || defined(__AVR_ATtiny1606__) || defined(__AVR_ATtiny1607__) || defined(__AVR_ATtiny1614__) || defined(__AVR_ATtiny1616__) \
+  || defined(__AVR_ATtiny1617__) || defined(__AVR_ATtiny3216__) || defined(__AVR_ATtiny3217__) )
+
+#define PIN_TO_BASEREG(pin)             (digitalPinToPortStruct(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_BITMASK_TYPE uint8_t
+#define IO_REG_TYPE PORT_t
+#define IO_REG_BASE_ATTR
+#define IO_REG_MASK_ATTR
+
+#define DIRECT_READ(port, mask)         ( (port->IN & mask) ? HIGH : LOW  )
+#define DIRECT_MODE_INPUT(port, mask)   ( { port->DIRCLR = mask; port->OUTCLR = mask;} )
+#define DIRECT_MODE_OUTPUT(port, mask)  ( port->DIRSET = mask )
+#define DIRECT_WRITE_LOW(port, mask)    ( port->OUTCLR = mask )
+#define DIRECT_WRITE_HIGH(port, mask)   ( port->OUTSET = mask )
+
+#elif defined(__AVR__)
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define IO_REG_TYPE uint8_t
@@ -432,6 +449,11 @@ void directWriteHigh(IO_REG_TYPE mask)
 #define DIRECT_MODE_OUTPUT(base, pin)   pinMode(pin,OUTPUT)
 #warning "OneWire. Fallback mode. Using API calls for pinMode,digitalRead and digitalWrite. Operation of this library is not guaranteed on this architecture."
 
+#endif
+
+// Define default IO_BITMASK_TYPE as same as IO_REG_TYPE
+#ifndef IO_BITMASK_TYPE
+#define IO_BITMASK_TYPE IO_REG_TYPE
 #endif
 
 #endif

--- a/util/OneWire_direct_regtype.h
+++ b/util/OneWire_direct_regtype.h
@@ -5,7 +5,14 @@
 
 // Platform specific I/O register type
 
-#if defined(__AVR__)
+#if (defined(__AVR_ATtiny804__) || defined(__AVR_ATtiny806__) || defined(__AVR_ATtiny807__) || defined(__AVR_ATtiny1604__) \
+  || defined(__AVR_ATtiny1606__) || defined(__AVR_ATtiny1607__) || defined(__AVR_ATtiny1614__) || defined(__AVR_ATtiny1616__) \
+  || defined(__AVR_ATtiny1617__) || defined(__AVR_ATtiny3216__) || defined(__AVR_ATtiny3217__) )
+
+	#define IO_REG_TYPE PORT_t
+	#define IO_BITMASK_TYPE uint8_t
+
+#elif defined(__AVR__)
 #define IO_REG_TYPE uint8_t
 
 #elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK66FX1M0__) || defined(__MK64FX512__)
@@ -52,4 +59,10 @@
 #define IO_REG_TYPE unsigned int
 
 #endif
+
+// Define default IO_BITMASK_TYPE as same as IO_REG_TYPE
+#ifndef IO_BITMASK_TYPE
+#define IO_BITMASK_TYPE IO_REG_TYPE
+#endif
+
 #endif


### PR DESCRIPTION
This patch add's support for new ATTiny-1 (and possibly ATTiny-0) MCUs like ATTiny1614 and ATTiny3216.
The code was tested with ATTiny1614 and ATTiny3216 using 10MHz internal clock.