### PR TITLE
Fix issue with getDeviceCount() on ESP32

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -195,7 +195,11 @@ uint8_t OneWire::reset(void)
 // Write a bit. Port and bit is used to cut lookup time and provide
 // more certain timing.
 //
+#if defined(ARDUINO_ARCH_ESP32)
+void IRAM_ATTR OneWire::write_bit(uint8_t v)
+#else
 void OneWire::write_bit(uint8_t v)
+#endif
 {
 	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
 	volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;
@@ -223,7 +227,11 @@ void OneWire::write_bit(uint8_t v)
 // Read a bit. Port and bit is used to cut lookup time and provide
 // more certain timing.
 //
+#if defined(ARDUINO_ARCH_ESP32)
+uint8_t IRAM_ATTR OneWire::read_bit(void)
+#else
 uint8_t OneWire::read_bit(void)
+#endif
 {
 	IO_REG_TYPE mask IO_REG_MASK_ATTR = bitmask;
 	volatile IO_REG_TYPE *reg IO_REG_BASE_ATTR = baseReg;

--- a/OneWire.h
+++ b/OneWire.h
@@ -99,10 +99,18 @@ class OneWire
 
     // Write a bit. The bus is always left powered at the end, see
     // note in write() about that.
+    #if defined (ARDUINO_ARCH_ESP32)
+    void IRAM_ATTR write_bit(uint8_t v);
+    #else
     void write_bit(uint8_t v);
+    #endif
 
     // Read a bit.
+    #if defined (ARDUINO_ARCH_ESP32)
+    uint8_t IRAM_ATTR read_bit(void);
+    #else
     uint8_t read_bit(void);
+    #endif
 
     // Stop forcing power onto the bus. You only need to do this if
     // you used the 'power' flag to write() or used a write_bit() call


### PR DESCRIPTION
This PR implements the changes suggested in "Error ds18b20 with esp32" #57.  Credits goes to the author of the fix. 

I can confirm that the getDS18Count()/getDeviceCount() always return 0 on a ESP32 system but this small change fixest that. I could see the fix needed but could not find a PR that actually changes the code.