### PR TITLE
Add inter-bit delay

### DIFF
--- a/OneWire.cpp
+++ b/OneWire.cpp
@@ -217,6 +217,7 @@ void OneWire::write_bit(uint8_t v)
 		interrupts();
 		delayMicroseconds(5);
 	}
+        delayMicroseconds(bit_delay);
 }
 
 //
@@ -238,6 +239,7 @@ uint8_t OneWire::read_bit(void)
 	r = DIRECT_READ(reg, mask);
 	interrupts();
 	delayMicroseconds(53);
+        delayMicroseconds(bit_delay);
 	return r;
 }
 
@@ -316,6 +318,10 @@ void OneWire::depower()
 	noInterrupts();
 	DIRECT_MODE_INPUT(baseReg, bitmask);
 	interrupts();
+}
+
+void OneWire::set_bit_delay(unsigned int d) {
+  bit_delay = d;
 }
 
 #if ONEWIRE_SEARCH

--- a/OneWire.h
+++ b/OneWire.h
@@ -60,6 +60,8 @@ class OneWire
     IO_REG_TYPE bitmask;
     volatile IO_REG_TYPE *baseReg;
 
+    unsigned int bit_delay = 0;
+
 #if ONEWIRE_SEARCH
     // global search state
     unsigned char ROM_NO[8];
@@ -111,6 +113,7 @@ class OneWire
     // someone shorts your bus.
     void depower(void);
 
+    void set_bit_delay(unsigned int d);
 #if ONEWIRE_SEARCH
     // Clear the search state so that if will start from the beginning again.
     void reset_search();


### PR DESCRIPTION
Please add delay between bits in message for slow 1-wire devices. For example, inter-bit delay is needed to program RW1990 touch memory. For example, writing new ID on such key could be as simple as
```
#include <OneWire.h>

OneWire ds(10); 

static const byte rw1990_key[] = {0x01, 0x27, 0x4f, 0x27, 0x01, 0x00, 0x00, 0xd5};

void cmd_rw1990_write(void) {
  if (!ds.reset()) {
    return;
  }
  ds.write(0xd1);
  ds.write_bit(0);
  _delay_ms(10);

  if (!ds.reset()) {
    return;
  }
  ds.write(0xd5);
  ds.set_bit_delay(2000);
  for (uint8_t i = 0; i < 8; i++) {
    ds.write(~rw1990_key[i]);
  }
  ds.set_bit_delay(0);
  
  if (!ds.reset()) {
    return;
  }
  ds.write(0xd1);
  ds.write_bit(1);
  _delay_ms(10);
}
```
(much simpler than original code at https://habr.com/ru/post/260891/ )