### PR TITLE
Add ESP32-C6 to conditionals

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -167,7 +167,7 @@ bool directRead(IO_REG_TYPE mask)
 static inline __attribute__((always_inline))
 IO_REG_TYPE directRead(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
     return (GPIO.in.val >> pin) & 0x1;
 #else // plain ESP32
     if ( pin < 32 )
@@ -182,7 +182,7 @@ IO_REG_TYPE directRead(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteLow(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.out_w1tc.val = ((uint32_t)1 << pin);
 #else // plain ESP32
     if ( pin < 32 )
@@ -195,7 +195,7 @@ void directWriteLow(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteHigh(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.out_w1ts.val = ((uint32_t)1 << pin);
 #else // plain ESP32
     if ( pin < 32 )
@@ -208,7 +208,7 @@ void directWriteHigh(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directModeInput(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.enable_w1tc.val = ((uint32_t)1 << (pin));
 #else
     if ( digitalPinIsValid(pin) )
@@ -234,7 +234,7 @@ void directModeInput(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directModeOutput(IO_REG_TYPE pin)
 {
-#if CONFIG_IDF_TARGET_ESP32C3
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
     GPIO.enable_w1ts.val = ((uint32_t)1 << (pin));
 #else
     if ( digitalPinIsValid(pin) && pin <= 33 ) // pins above 33 can be only inputs


### PR DESCRIPTION
This adds the C6 to the conditionals for the C3.
Builds currently fail when attempting to build for the Espressif ESP32-C6 DevkitM-1 (4mb flash no psram)