### PR TITLE
Fix missing GPIO definition

### DIFF
--- a/util/OneWire_direct_gpio.h
+++ b/util/OneWire_direct_gpio.h
@@ -157,7 +157,7 @@ bool directRead(IO_REG_TYPE mask)
 
 #elif defined(ARDUINO_ARCH_ESP32)
 #include <driver/rtc_io.h>
-#include <soc/gpio_struct.h>
+#include <hal/gpio_ll.h>
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             (pin)
 #define IO_REG_TYPE uint32_t


### PR DESCRIPTION
Fixes the GPIO definition error for esp32 with IDF > v5.